### PR TITLE
Fix bookmark folder order

### DIFF
--- a/src/selectors/getBookmarkTree.ts
+++ b/src/selectors/getBookmarkTree.ts
@@ -5,10 +5,15 @@ import { getIsBookmarkHidden } from "./getIsBookmarkHidden";
 export const getBookmarkTree = (state: ReduxState): BookmarkTree => {
   const { foldersById, bookmarksById } = state.bookmarks;
   const { query, isShowingHiddenBookmark } = state.session;
-  const folders: BookmarkTree = Object.keys(foldersById).map(folderId => ({
-    ...foldersById[folderId],
-    bookmarks: []
-  }));
+  const folders: BookmarkTree = Object.entries(foldersById)
+    .sort(
+      ([keyA, { nodeOrder: nodeOrderA }], [keyB, { nodeOrder: nodeOrderB }]) =>
+        nodeOrderA! - nodeOrderB!
+    )
+    .map(([folderId]) => ({
+      ...foldersById[folderId],
+      bookmarks: []
+    }));
   Object.keys(bookmarksById).forEach(bookmarkId => {
     const bookmark = bookmarksById[bookmarkId];
     const isHidden = getIsBookmarkHidden(state, bookmark.id);

--- a/src/types/ChromeBookmark.ts
+++ b/src/types/ChromeBookmark.ts
@@ -1,1 +1,3 @@
-export type ChromeBookmark = chrome.bookmarks.BookmarkTreeNode;
+export type ChromeBookmark = chrome.bookmarks.BookmarkTreeNode & {
+  nodeOrder?: number;
+};

--- a/src/utils/parseBookmarkTree.ts
+++ b/src/utils/parseBookmarkTree.ts
@@ -9,15 +9,17 @@ const withoutChildren = (bookmark: ChromeBookmark) => ({
   dateGroupModified: bookmark.dateGroupModified,
   id: bookmark.id,
   parentId: bookmark.parentId,
-  unmodifiable: bookmark.unmodifiable
+  unmodifiable: bookmark.unmodifiable,
+  nodeOrder: bookmark.nodeOrder
 });
 
 export const parseBookmarkTree = (bookmarkTree: ChromeBookmark[]) => {
   const foldersById: ChromeBookmarksById = {};
   const bookmarksById: ChromeBookmarksById = {};
-  const a = Date.now();
+  let nodeOrder = 0;
   const parseBookmarkNodes = (nodes: ChromeBookmark[]) => {
     nodes.forEach(node => {
+      node.nodeOrder = nodeOrder++;
       if (node.children) {
         foldersById[node.id] = withoutChildren(node);
         parseBookmarkNodes(node.children);


### PR DESCRIPTION
Hi!

Thank you for the extension! Really nicely done.

Small issue:

When folders are created in Chrome, they're assigned unique ID for the duration of their life. If folder is later moved to a different position, it keeps the ID. So, folder with higher ID, can come before folder with lower ID. Because `foldersById` is an object, it does not guarantee object property order, so naturally, when we append to `folderById` by use of `foldersById[node.id]` order of the folders is not kept. 

This pull request is an attempt at fixing it :) I could've sorted by parentId + index on `ChromeBookmark`, but I've decided to add an additional field, this way it ensures nested folders come after one another too. 

Let me know what you think! 