### PR TITLE
Add autofocus prop

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -25,6 +25,7 @@ export const SearchBar = forwardRef<HTMLInputElement, Props>((props, ref) => {
         type="text"
         onChange={handleInputChange}
         value={query}
+        autofocus
       />
     </Form>
   );


### PR DESCRIPTION
Adding the autofocus prop would allow the user to instantly search for bookmarks, rather then clicking into the search field first.